### PR TITLE
fix: allow default export in next.js middleware

### DIFF
--- a/.changeset/warm-flies-happen.md
+++ b/.changeset/warm-flies-happen.md
@@ -1,0 +1,5 @@
+---
+"@stefanprobst/eslint-config-next": patch
+---
+
+allow default export in next.js middleware

--- a/packages/next/config.js
+++ b/packages/next/config.js
@@ -22,7 +22,7 @@ const config = {
 			},
 		},
 		{
-			files: ["./src/pages/**/*.api.ts"],
+			files: ["./src/pages/**/*.api.ts", "./src/middleware.ts"],
 			rules: {
 				"import/no-default-export": "off",
 			},


### PR DESCRIPTION
allows default export in next.js middleware