### PR TITLE
fix: allow default exports in new next.js app folder

### DIFF
--- a/packages/next/config.js
+++ b/packages/next/config.js
@@ -27,6 +27,20 @@ const config = {
 				"import/no-default-export": "off",
 			},
 		},
+		{
+			files: [
+				"./src/app/**/error.tsx",
+				"./src/app/**/head.tsx",
+				"./src/app/**/layout.tsx",
+				"./src/app/**/loading.tsx",
+				"./src/app/**/not-found.tsx",
+				"./src/app/**/page.tsx",
+				"./src/app/**/template.tsx",
+			],
+			rules: {
+				"import/no-default-export": "off",
+			},
+		},
 	],
 };
 


### PR DESCRIPTION
allow default exports in new next.js app folder